### PR TITLE
Commented out break statement in test_off.sh

### DIFF
--- a/test_off.sh
+++ b/test_off.sh
@@ -39,7 +39,7 @@ echo -n "Trying $m: "
         ;;
         *)
             echo "works!"
-            break
+            #break
         ;;
         esac
 done


### PR DESCRIPTION
Sometimes the first positive result found by test_off.sh is not the correct switch for the graphics card in question. It is better to test for all possible switches before quitting the script, so that the user gets an exhaustive list of all working (and non-working) switches.
