### PR TITLE
Use linux/acpi.h instead of acpi/acpi.h

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -6,7 +6,7 @@
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
 #include <asm/uaccess.h>
-#include <acpi/acpi.h>
+#include <linux/acpi.h>
 
 MODULE_LICENSE("GPL");
 


### PR DESCRIPTION
This fixes a small build error when building against recent kernels (kernel 3.17)

The conflicting change is this one:
https://git.kernel.org/cgit/linux/kernel/git/stable/linux-stable.git/commit/?id=417b4a73b62760db67512892c32f8acc008ab54e
