### PR TITLE
fix error

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -5,8 +5,8 @@
 #include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
+#include <linux/acpi.h>
 #include <asm/uaccess.h>
-#include <acpi/acpi.h>
 
 MODULE_LICENSE("GPL");
 


### PR DESCRIPTION
In file included from include/acpi/platform/acenv.h:172:0, from include/acpi/acpi.h:56, from /home/bcarmer/acpi_call-git/src/acpi_call/acpi_call.c:9: include/acpi/platform/aclinux.h:52:2: error: #error "Please don't include <acpi/acpi.h> directly, include <linux/acpi.h> instead."
