### PR TITLE
Resolve <acpi/acpi.h> directly and %lu to size_t

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -6,7 +6,7 @@
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
 #include <asm/uaccess.h>
-#include <acpi/acpi.h>
+#include <linux/acpi.h>
 
 MODULE_LICENSE("GPL");
 
@@ -270,7 +270,11 @@ static int acpi_proc_write( struct file *filp, const char __user *buff,
     char *method;
 
     if (len > sizeof(input) - 1) {
+#ifdef HAVE_PROC_CREATE
+        printk(KERN_ERR "acpi_call: Input too long! (%u)\n", len);
+#else
         printk(KERN_ERR "acpi_call: Input too long! (%lu)\n", len);
+#endif
         return -ENOSPC;
     }
 


### PR DESCRIPTION
/usr/src/linux-headers-4.1.0-2-common/include/acpi/platform/aclinux.h:52:2: error: #error "Please don't include <acpi/acpi.h> directly, include <linux/acpi.h> instead."
 #error "Please don't include <acpi/acpi.h> directly, include <linux/acpi.h> instead."
  ^

/tmp/acpi_call/acpi_call.c: In function ‘acpi_proc_write’:
/tmp/acpi_call/acpi_call.c:273:9: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘size_t’ [-Wformat=]
         printk(KERN_ERR "acpi_call: Input too long! (%lu)\n", len);
         ^
