### PR TITLE
Update turn_off_gpu.sh - Display controller: Advanced Micro Devices, Inc. [AMD/ATI] Topaz XT [Radeon R7 M260/M265]

### DIFF
--- a/examples/turn_off_gpu.sh
+++ b/examples/turn_off_gpu.sh
@@ -2,6 +2,7 @@
 
 if lsmod | grep -q acpi_call; then
 methods="
+\_SB_.PCI0.GFX0.ATPX
 \_SB.PCI0.P0P1.VGA._OFF
 \_SB.PCI0.P0P2.VGA._OFF
 \_SB_.PCI0.OVGA.ATPX


### PR DESCRIPTION
04:00.0 Display controller: Advanced Micro Devices, Inc. [AMD/ATI] Topaz XT [Radeon R7 M260/M265]

Discrete part of the following AMD/ATI+Intel Hybrid GPU:
00:02.0 VGA compatible controller: Intel Corporation Broadwell-U Integrated Graphics (rev 09)
