### PR TITLE
Include uaccess.h from linux rather than asm path

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -5,7 +5,7 @@
 #include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
-#include <asm/uaccess.h>
+#include <linux/uaccess.h>
 #include <acpi/acpi.h>
 
 MODULE_LICENSE("GPL");

--- a/acpi_call.c
+++ b/acpi_call.c
@@ -6,7 +6,7 @@
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
 #include <linux/uaccess.h>
-#include <acpi/acpi.h>
+#include <linux/acpi.h>
 
 MODULE_LICENSE("GPL");
 

--- a/acpi_call.c
+++ b/acpi_call.c
@@ -288,9 +288,10 @@ static int acpi_proc_write( struct file *filp, const char __user *buff,
             for (i=0; i<nargs; i++)
                 if (args[i].type == ACPI_TYPE_BUFFER)
                     kfree(args[i].buffer.pointer);
-            kfree(args);
         }
     }
+    if (args)
+        kfree(args);
 
     return len;
 }


### PR DESCRIPTION
This fixes a build issue on 4.12 kernels (LP: #1700783)

Signed-off-by: Colin Ian King <colin.king@canonical.com>