### PR TITLE
Linux 4.12 compat

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -5,8 +5,16 @@
 #include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#include <linux/uaccess.h>
+#else
 #include <asm/uaccess.h>
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0)
+#include <linux/acpi.h>
+#else
 #include <acpi/acpi.h>
+#endif
 
 MODULE_LICENSE("GPL");
 


### PR DESCRIPTION
Linux 4.12 introduced some changes with headers which break compilation:
```
hamako acpi_call # make
make -C /lib/modules/4.12.0-gentoo-hamako/build M=/tmp/acpi_call modules
make[1]: Entering directory '/usr/src/linux-4.12.0-gentoo'
  CC [M]  /tmp/acpi_call/acpi_call.o
In file included from ./include/acpi/platform/acenv.h:186:0,
                 from ./include/acpi/acpi.h:56,
                 from /tmp/acpi_call/acpi_call.c:9:
./include/acpi/platform/aclinux.h:52:2: error: #error "Please don't include <acpi/acpi.h> directly, include <linux/acpi.h> instead."
 #error "Please don't include <acpi/acpi.h> directly, include <linux/acpi.h> instead."
  ^
/tmp/acpi_call/acpi_call.c: In function ‘acpi_proc_write’:
/tmp/acpi_call/acpi_call.c:277:5: error: implicit declaration of function ‘copy_from_user’ [-Werror=implicit-function-declaration]
     if (copy_from_user( input, buff, len )) {
     ^
cc1: some warnings being treated as errors
make[2]: *** [scripts/Makefile.build:309: /tmp/acpi_call/acpi_call.o] Error 1
make[1]: *** [Makefile:1512: _module_/tmp/acpi_call] Error 2
make[1]: Leaving directory '/usr/src/linux-4.12.0-gentoo'
make: *** [Makefile:8: default] Error 2
```

Attached PR changes ACPI include to linux/acpi for 4.12 and includes linux/uaccess.h instead of asm/uaccess.h.