### PR TITLE
Fixing the build for kernel 4.5.10

### DIFF
--- a/acpi_call.c
+++ b/acpi_call.c
@@ -5,8 +5,8 @@
 #include <linux/version.h>
 #include <linux/proc_fs.h>
 #include <linux/slab.h>
-#include <asm/uaccess.h>
-#include <acpi/acpi.h>
+#include <linux/uaccess.h>
+#include <linux/acpi.h>
 
 MODULE_LICENSE("GPL");
 


### PR DESCRIPTION
Changing the includes to get the build on 4.5.10 kernel work.