### PR TITLE
Updated example/turn_off_gpu.sh to avoid null byte in input warning

### DIFF
--- a/examples/turn_off_gpu.sh
+++ b/examples/turn_off_gpu.sh
@@ -36,7 +36,7 @@ methods="
 for m in $methods; do
     echo -n "Trying $m: "
     echo $m > /proc/acpi/call
-    result=$(cat /proc/acpi/call)
+    result=$(tr -d '\0' </proc/acpi/call)
     case "$result" in
         Error*)
             echo "failed"


### PR DESCRIPTION
Small change to avoid an annoying error. Thanks for the utility! 